### PR TITLE
Assigning a fix Version to a set of issues.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@
 # Please keep the list sorted.
 
 Geert van Horrik <geert@catenalogic.com>
+Darrell Tunnell <darrell.tunnell@googlemail.com>

--- a/src/JiraCli.Tests/ArgumentParserFacts.cs
+++ b/src/JiraCli.Tests/ArgumentParserFacts.cs
@@ -10,6 +10,7 @@ namespace JiraCli.Test
     using Catel.Test;
     using JiraCli;
     using NUnit.Framework;
+    using Services;
 
     [TestFixture]
     public class ArgumentParserFacts
@@ -36,6 +37,18 @@ namespace JiraCli.Test
             var context = ArgumentParser.ParseArguments("-h");
 
             Assert.IsTrue(context.IsHelp);
+        }
+
+        [TestCase("-project TT -version 0.0.2 -issues \"TEST-1,TEST-2,TEST-3\"")]
+        [TestCase("-project TT -version 0.0.1-unstable0001 -issues \"TEST-1, TEST-2, TEST-3\"")]
+        public void CorrectlyParsesAssignVersionCommand(string commandLine)
+        {
+            var context = ArgumentParser.ParseArguments(commandLine);
+
+            Assert.IsNotNull(context.Issues);
+            Assert.IsNotEmpty(context.Issues);
+            Assert.IsNotNullOrEmpty(context.Project);
+            Assert.IsNotNullOrEmpty(context.Version);
         }
 
         //[TestCase]
@@ -84,4 +97,6 @@ namespace JiraCli.Test
             ExceptionTester.CallMethodAndExpectException<JiraCliException>(() => ArgumentParser.ParseArguments("solutionDirectory -x logFilePath"));
         }
     }
+
+  
 }

--- a/src/JiraCli.Tests/ArgumentParserFacts.cs
+++ b/src/JiraCli.Tests/ArgumentParserFacts.cs
@@ -10,7 +10,6 @@ namespace JiraCli.Test
     using Catel.Test;
     using JiraCli;
     using NUnit.Framework;
-    using Services;
 
     [TestFixture]
     public class ArgumentParserFacts

--- a/src/JiraCli.Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/JiraCli.Tests/IntegrationTests/IntegrationTests.cs
@@ -36,7 +36,7 @@ namespace JiraCli.Tests.IntegrationTests
                 UserName = JiraUser,
                 Password = JiraPassword,
                 Version = version,
-                Issues = issues
+                Issues = issues ?? new string[] { }
             };
 
             return context;
@@ -79,8 +79,8 @@ namespace JiraCli.Tests.IntegrationTests
             var createStableVersionContext = CreateContext("2.0.0");
             Assert.IsTrue(await action.Execute(createStableVersionContext));
         }
-
         
+     
         [TestCase("TS-1,TS-2,TS-3")]
         public async Task AssignVersion(string issueNumbers)
         {

--- a/src/JiraCli.Tests/IntegrationTests/IntegrationTests.cs
+++ b/src/JiraCli.Tests/IntegrationTests/IntegrationTests.cs
@@ -7,6 +7,7 @@
 
 namespace JiraCli.Tests.IntegrationTests
 {
+    using System;
     using System.Threading.Tasks;
     using Catel;
     using Catel.IoC;
@@ -26,7 +27,7 @@ namespace JiraCli.Tests.IntegrationTests
             return ServiceLocator.Default.ResolveType<T>();
         }
 
-        private Context CreateContext(string version)
+        private Context CreateContext(string version, string[] issues = null)
         {
             var context = new Context
             {
@@ -34,7 +35,8 @@ namespace JiraCli.Tests.IntegrationTests
                 Project = JiraProject,
                 UserName = JiraUser,
                 Password = JiraPassword,
-                Version = version
+                Version = version,
+                Issues = issues
             };
 
             return context;
@@ -76,6 +78,21 @@ namespace JiraCli.Tests.IntegrationTests
 
             var createStableVersionContext = CreateContext("2.0.0");
             Assert.IsTrue(await action.Execute(createStableVersionContext));
+        }
+
+        
+        [TestCase("TS-1,TS-2,TS-3")]
+        public async Task AssignVersion(string issueNumbers)
+        {
+
+            var actionManager = ResolveService<IActionManager>();
+
+            var action = actionManager.GetAction("AssignVersion");
+            var issues = issueNumbers.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            var createV100Context = CreateContext("1.0.0", issues);
+            Assert.IsTrue(await action.Execute(createV100Context));
+
         }
     }
 }

--- a/src/JiraCli/Actions/AssignVersion/AssignVersionAction.cs
+++ b/src/JiraCli/Actions/AssignVersion/AssignVersionAction.cs
@@ -1,0 +1,58 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CreateAndReleaseVersionAction.cs" company="CatenaLogic">
+//   Copyright (c) 2014 - 2014 CatenaLogic. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace JiraCli
+{
+    using System.Linq;
+    using Catel;
+    using Catel.Logging;
+    using Services;
+
+    [Action("AssignVersion",
+        Description = "Assigns a version to the issues specified",
+        ArgumentsUsage = "-project [projectkey] -version [version] -issues [issue1,issues2,issue3]")]
+    public class AssignVersionAction : ActionBase
+    {
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+        private readonly IVersionService _versionService;
+
+        public AssignVersionAction(IVersionService versionService)
+        {
+            Argument.IsNotNull(() => versionService);
+
+            _versionService = versionService;
+        }
+
+        protected override void ValidateContext(Context context)
+        {
+            if (string.IsNullOrEmpty(context.Project))
+            {
+                Log.ErrorAndThrowException<JiraCliException>("Project is missing");
+            }
+
+            if (string.IsNullOrEmpty(context.Version))
+            {
+                Log.ErrorAndThrowException<JiraCliException>("Version is missing");
+            }
+
+            if (context.Issues == null || !context.Issues.Any())
+            {
+                Log.ErrorAndThrowException<JiraCliException>("Issues are missing.");
+            }
+        }
+
+        protected override void ExecuteWithContext(Context context)
+        {
+            // Note: we need a different instance of jira because it caches results
+
+            var createVersionJira = CreateJira(context);
+            //  var version = _versionService.
+            _versionService.AssignVersionToIssues(createVersionJira, context.Project, context.Version, context.Issues);
+
+        }
+    }
+}

--- a/src/JiraCli/Actions/AssignVersion/AssignVersionAction.cs
+++ b/src/JiraCli/Actions/AssignVersion/AssignVersionAction.cs
@@ -39,7 +39,7 @@ namespace JiraCli
                 Log.ErrorAndThrowException<JiraCliException>("Version is missing");
             }
 
-            if (context.Issues == null || !context.Issues.Any())
+            if (!context.Issues.Any())
             {
                 Log.ErrorAndThrowException<JiraCliException>("Issues are missing.");
             }

--- a/src/JiraCli/ArgumentParser.cs
+++ b/src/JiraCli/ArgumentParser.cs
@@ -21,7 +21,7 @@ namespace JiraCli
         public static Context ParseArguments(string commandLineArguments)
         {
             var args = SplitCommandLine(commandLineArguments).ToArray();
-            return ParseArguments(args); // ParseArguments(commandLineArguments.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList());
+            return ParseArguments(args);
         }
 
         public static Context ParseArguments(params string[] commandLineArguments)
@@ -165,16 +165,6 @@ namespace JiraCli
                    IsSwitch("help", singleArgument) ||
                    IsSwitch("?", singleArgument);
         }
-
-        //public static IEnumerable<string> SplitCSV(string input)
-        //{
-        //    Regex csvSplit = new Regex("(?:^|,)(\"(?:[^\"]+|\"\")*\"|[^,]*)", RegexOptions.Compiled);
-
-        //    foreach (Match match in csvSplit.Matches(input))
-        //    {
-        //        yield return match.Value.TrimStart(',').Trim();
-        //    }
-        //}
 
         /// <summary>
         /// Shamelessly taken from stackoverflow: http://stackoverflow.com/questions/298830/split-string-containing-command-line-parameters-into-string-in-c-sharp/298990#298990

--- a/src/JiraCli/ArgumentParser.cs
+++ b/src/JiraCli/ArgumentParser.cs
@@ -107,6 +107,12 @@ namespace JiraCli
                     continue;
                 }
 
+                if (IsSwitch("issues", name))
+                {
+                    context.Issues = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    continue;
+                }
+
                 //if (IsSwitch("ci", name))
                 //{
                 //    bool isCi;

--- a/src/JiraCli/ArgumentParser.cs
+++ b/src/JiraCli/ArgumentParser.cs
@@ -175,40 +175,40 @@ namespace JiraCli
         {
             bool inQuotes = false;
 
-            return commandLine.Split(c =>
+            return Split(commandLine, c =>
             {
                 if (c == '\"')
                     inQuotes = !inQuotes;
 
                 return !inQuotes && c == ' ';
             })
-                              .Select(arg => arg.Trim().TrimMatchingQuotes('\"'))
-                              .Where(arg => !string.IsNullOrEmpty(arg));
+            .Select(arg => TrimMatchingQuotes(arg.Trim(), '\"'))
+            .Where(arg => !string.IsNullOrEmpty(arg));
         }
 
-        public static IEnumerable<string> Split(this string str, Func<char, bool> controller)
+        private static IEnumerable<string> Split(string inputString, Predicate<char> shouldSplit)
         {
             int nextPiece = 0;
 
-            for (int c = 0; c < str.Length; c++)
+            for (int c = 0; c < inputString.Length; c++)
             {
-                if (controller(str[c]))
+                if (shouldSplit(inputString[c]))
                 {
-                    yield return str.Substring(nextPiece, c - nextPiece);
+                    yield return inputString.Substring(nextPiece, c - nextPiece);
                     nextPiece = c + 1;
                 }
             }
 
-            yield return str.Substring(nextPiece);
+            yield return inputString.Substring(nextPiece);
         }
 
-        public static string TrimMatchingQuotes(this string input, char quote)
+        private static string TrimMatchingQuotes(string inputString, char quote)
         {
-            if ((input.Length >= 2) &&
-                (input[0] == quote) && (input[input.Length - 1] == quote))
-                return input.Substring(1, input.Length - 2);
+            if ((inputString.Length >= 2) &&
+                (inputString[0] == quote) && (inputString[inputString.Length - 1] == quote))
+                return inputString.Substring(1, inputString.Length - 2);
 
-            return input;
+            return inputString;
         }
     }
 }

--- a/src/JiraCli/Context.cs
+++ b/src/JiraCli/Context.cs
@@ -29,6 +29,8 @@ namespace JiraCli
         public string Project { get; set; }
         public string Version { get; set; }
 
+        public string[] Issues { get; set; }
+
         public bool MergeVersions { get; set; }
 
         public void ValidateContext()

--- a/src/JiraCli/Context.cs
+++ b/src/JiraCli/Context.cs
@@ -15,6 +15,7 @@ namespace JiraCli
 
         public Context()
         {
+            this.Issues = new string[] { };
         }
 
         public bool IsHelp { get; set; }

--- a/src/JiraCli/Extensions/JiraExtensions.version.cs
+++ b/src/JiraCli/Extensions/JiraExtensions.version.cs
@@ -30,6 +30,18 @@ namespace JiraCli
             var responseJson = jiraRestClient.ExecuteRequestRaw(Method.POST, resource, requestJson);
         }
 
+
+        public static void UpdateIssue(this IJiraRestClient jiraRestClient, string issueNumber, JiraIssueUpdate updateIssue)
+        {
+            Argument.IsNotNull(() => jiraRestClient);
+            Argument.IsNotNull(() => updateIssue);
+
+            var requestJson = JsonConvert.SerializeObject(updateIssue, GetJsonSettings());
+
+            var resource = $"rest/api/2/issue/{issueNumber}";
+            var responseJson = jiraRestClient.ExecuteRequestRaw(Method.PUT, resource, requestJson);
+        }
+
         public static void UpdateProjectVersion(this IJiraRestClient jiraRestClient, JiraProjectVersion projectVersion)
         {
             Argument.IsNotNull(() => jiraRestClient);

--- a/src/JiraCli/JiraCli.csproj
+++ b/src/JiraCli/JiraCli.csproj
@@ -98,6 +98,7 @@
       <Link>Properties\SolutionAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Actions\ActionBase.cs" />
+    <Compile Include="Actions\AssignVersion\AssignVersionAction.cs" />
     <Compile Include="Actions\CreateAndReleaseVersion\CreateAndReleaseVersionAction.cs" />
     <Compile Include="Actions\CreateVersion\CreateVersionAction.cs" />
     <Compile Include="Actions\Interfaces\IAction.cs" />
@@ -119,6 +120,7 @@
     <Compile Include="Managers\ActionManager.cs" />
     <Compile Include="Managers\Interfaces\IActionManager.cs" />
     <Compile Include="Models\JiraIssue.cs" />
+    <Compile Include="Models\JiraIssueUpdate.cs" />
     <Compile Include="Models\JiraObjectBase.cs" />
     <Compile Include="Models\JiraProject.cs" />
     <Compile Include="Models\JiraProjectVersion.cs" />

--- a/src/JiraCli/Models/JiraIssueUpdate.cs
+++ b/src/JiraCli/Models/JiraIssueUpdate.cs
@@ -1,0 +1,27 @@
+﻿namespace JiraCli.Models
+{
+    using System.Collections.Generic;
+    using System.ComponentModel;
+
+    public class JiraIssueUpdate : JiraObjectBase
+    {
+
+        public JiraIssueUpdate()
+        {
+            Update = new Dictionary<string, object>();
+        }
+
+        public void AddFieldValue(string name, object value)
+        {
+            var array = new List<object>();
+            // array.Add("add", value);
+            array.Add(new { Add = value });
+            Update[name] = array;
+        }
+      
+        public Dictionary<string, object> Update { get; set; }
+
+    }
+
+
+}

--- a/src/JiraCli/Services/Interfaces/IVersionService.cs
+++ b/src/JiraCli/Services/Interfaces/IVersionService.cs
@@ -14,5 +14,6 @@ namespace JiraCli.Services
         void CreateVersion(IJiraRestClient jiraRestClient, string projectKey, string version);
         void ReleaseVersion(IJiraRestClient jiraRestClient, string projectKey, string version);
         void MergeVersions(IJiraRestClient jiraRestClient, string projectKey, string version);
+        void AssignVersionToIssues(IJiraRestClient jiraRestClient, string projectKey, string version, string[] issues);
     }
 }

--- a/src/JiraCli/Services/VersionService.cs
+++ b/src/JiraCli/Services/VersionService.cs
@@ -51,12 +51,10 @@ namespace JiraCli.Services
             var existingVersion = GetProjectVersion(jiraRestClient, projectKey, version);
             if (existingVersion == null)
             {
-                var error = string.Format("Version '{0}' does not exist/ Ensure you have created this version first.", version);
-                Log.Error(error);
-                throw new InvalidOperationException(error);
+                Log.ErrorAndThrowException<InvalidOperationException>($"Version '{version}' does not exist / ensure you have created this version first");
             }
 
-            Log.Info("Version '{0}' exists", version);
+            Log.Info($"Version '{version}' exists, going to set this as FixVersion for '{issues.Length}' issues");
 
             // update issues
             var issueUpdate = new JiraIssueUpdate();
@@ -88,9 +86,7 @@ namespace JiraCli.Services
 
                 if (existingVersion.Released)
                 {
-                    var error = string.Format("Version '{0}' is already released, are you re-releasing an existing version?", version);
-                    Log.Error(error);
-                    throw new InvalidOperationException(error);
+                    Log.ErrorAndThrowException<InvalidOperationException>($"Version '{version}' is already released, are you re-releasing an existing version?");
                 }
 
                 return;
@@ -101,9 +97,7 @@ namespace JiraCli.Services
             var project = GetProject(jiraRestClient, projectKey);
             if (project == null)
             {
-                var error = string.Format("Project '{0}' cannot be found or current user does not have access to the project", projectKey);
-                Log.Error(error);
-                throw new InvalidOperationException(error);
+                Log.ErrorAndThrowException<InvalidOperationException>($"Project '{projectKey}' cannot be found or current user does not have access to the project");
             }
 
             jiraRestClient.CreateProjectVersion(new JiraProjectVersion
@@ -126,9 +120,7 @@ namespace JiraCli.Services
             var projectVersion = GetProjectVersion(jiraRestClient, projectKey, version);
             if (projectVersion == null)
             {
-                var error = string.Format("Version {0} does not exist, make sure to create it first", version);
-                Log.Error(error);
-                throw new InvalidOperationException(error);
+                Log.ErrorAndThrowException<InvalidOperationException>($"Version '{version}' does not exist / ensure you have created this version first");
             }
 
             if (projectVersion.Released)


### PR DESCRIPTION
This PR is to add an action to the command line, that allows assigning a fix Version to a specified set of issues (for #4)

The fix version must already be created, and the issues must already exist.

The command line is:

`[basecall] -action AssignVersion -project "KEY" -version 0.0.1 -issues "KEY-1,KEY-2,KEY-3"`

The update only appends the specified version to the fix version field on the issues, it won't overwrite or remove existing fix versions in the field.
