### PR TITLE
Closes #9 (Candidates for Merge)

### DIFF
--- a/src/JiraCli.Tests/Services/MergeVersionServiceFacts.cs
+++ b/src/JiraCli.Tests/Services/MergeVersionServiceFacts.cs
@@ -16,7 +16,9 @@ namespace JiraCli.Tests.Services
         [TestCase("1.0.0", "1.1.0", false)]
         [TestCase("1.0.0-unstable0016", "1.1.0", false)]
         [TestCase("1.0.0", "1.1.0-unstable0016", false)]
+        [TestCase("1.0.0", "1.0.0-beta0016", false)]
         [TestCase("1.0.0", "1.0.0-unstable0016", true)]
+        [TestCase("1.0.0", "0.0.1-unstable0016", true)]
         public void TheShouldBeMergedMethod(string versionBeingReleased, string versionToCheck, bool expectedValue)
         {
             var mergeVersionService = new MergeVersionService(new VersionInfoService());
@@ -25,5 +27,6 @@ namespace JiraCli.Tests.Services
 
             Assert.AreEqual(expectedValue, shouldBeMerged);
         }
+       
     }
 }

--- a/src/JiraCli.Tests/Services/VersionInfoServiceFacts.cs
+++ b/src/JiraCli.Tests/Services/VersionInfoServiceFacts.cs
@@ -19,6 +19,7 @@ namespace JiraCli.Tests.Services
         [TestCase("1.0.0.0", true)]
         [TestCase("1.0.15.12", true)]
         [TestCase("1.0.15-unstable0016", false)]
+        [TestCase("1.0.15-unstable.1", false)]
         [TestCase("1.0.15-beta0016", false)]
         [TestCase("1.0.15-prerelease0016", false)]
         [TestCase("1.0.15.0-unstable0016", false)]
@@ -28,8 +29,40 @@ namespace JiraCli.Tests.Services
         {
             var versionInfoService = new VersionInfoService();
 
-            var actualValue = versionInfoService.IsStableVersion(version);
+            var actualValue = versionInfoService.IsReleaseVersion(version);
 
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestCase("0.1.0", "1.0.0", VersionComparisonResult.LessThan)]
+        [TestCase("0.1.0-unstable.1", "0.1.0", VersionComparisonResult.LessThan)]
+        [TestCase("0.1.0-unstable.1", "1.0.0", VersionComparisonResult.LessThan)]
+        [TestCase("0.1.0-unstable.1", "0.1.0-unstable.2", VersionComparisonResult.LessThan)]
+        [TestCase("0.1.0-unstable.1", "0.1.0-beta.1", VersionComparisonResult.GreaterThan)]
+        [TestCase("0.1.0", "0.1.0", VersionComparisonResult.Equal)]
+        [TestCase("0.1.0.0", "1.0.0.0", VersionComparisonResult.LessThan)]
+        public void TheCompareVersionMethod(string versionToCheck, string compareToVersion, VersionComparisonResult expectedValue)
+        {
+            var versionInfoService = new VersionInfoService();
+            var actualValue = versionInfoService.CompareVersions(versionToCheck, compareToVersion);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            if (expectedValue == VersionComparisonResult.Equal)
+            {
+                return;
+            }
+
+            // check the inverse comparison is also true.
+            if (expectedValue == VersionComparisonResult.LessThan)
+            {
+                expectedValue = VersionComparisonResult.GreaterThan;
+            }
+            else if (expectedValue == VersionComparisonResult.GreaterThan)
+            {
+                expectedValue = VersionComparisonResult.LessThan;
+            }
+
+            actualValue = versionInfoService.CompareVersions(compareToVersion, versionToCheck);
             Assert.AreEqual(expectedValue, actualValue);
         }
     }

--- a/src/JiraCli.sln
+++ b/src/JiraCli.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraCli", "JiraCli\JiraCli.csproj", "{306289C1-A5C5-4C32-BAFE-C1F7E5331291}"
 EndProject

--- a/src/JiraCli/Context.cs
+++ b/src/JiraCli/Context.cs
@@ -29,7 +29,6 @@ namespace JiraCli
 
         public string Project { get; set; }
         public string Version { get; set; }
-
         public string[] Issues { get; set; }
 
         public bool MergeVersions { get; set; }

--- a/src/JiraCli/JiraCli.csproj
+++ b/src/JiraCli/JiraCli.csproj
@@ -71,6 +71,10 @@
       <HintPath>..\..\lib\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Semver">
+      <HintPath>..\..\lib\semver.1.1.2\lib\net40\Semver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO">
@@ -128,6 +132,7 @@
     <Compile Include="ModuleInitializer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\Interfaces\VersionComparisonResult.cs" />
     <Compile Include="Services\Interfaces\IMergeVersionService.cs" />
     <Compile Include="Services\Interfaces\IVersionService.cs" />
     <Compile Include="Services\Interfaces\IVersionInfoService.cs" />

--- a/src/JiraCli/Services/Interfaces/IVersionInfoService.cs
+++ b/src/JiraCli/Services/Interfaces/IVersionInfoService.cs
@@ -9,6 +9,9 @@ namespace JiraCli.Services
 {
     public interface IVersionInfoService
     {
-        bool IsStableVersion(string version);
+        bool IsPreReleaseWithLabelPrefix(string version, string labelPrefix);
+        bool IsReleaseVersion(string version);
+        VersionComparisonResult CompareVersions(string versionToCheck, string versionBeingReleased);
+
     }
 }

--- a/src/JiraCli/Services/Interfaces/VersionComparisonResult.cs
+++ b/src/JiraCli/Services/Interfaces/VersionComparisonResult.cs
@@ -1,0 +1,10 @@
+﻿namespace JiraCli.Services
+{
+    public enum VersionComparisonResult
+    {
+        LessThan = -1,
+        Equal = 0,
+        GreaterThan = 1,
+        Unknown = 99
+    }
+}

--- a/src/JiraCli/Services/MergeVersionService.cs
+++ b/src/JiraCli/Services/MergeVersionService.cs
@@ -47,9 +47,11 @@ namespace JiraCli.Services
             {
                 case VersionComparisonResult.LessThan:
                     return true;
+
                 case VersionComparisonResult.Unknown:
-                    Log.Warning("Unable to compare version {0} with version {1}. Version {0} will not be included in the Merge.", versionToCheck, versionBeingReleased);
+                    Log.Warning("Unable to compare version '{0}' with version '{1}'. Version will not be included in the Merge.", versionToCheck, versionBeingReleased);
                     return false;
+
                 default:
                     return false;
             }

--- a/src/JiraCli/Services/MergeVersionService.cs
+++ b/src/JiraCli/Services/MergeVersionService.cs
@@ -29,17 +29,31 @@ namespace JiraCli.Services
             Argument.IsNotNull(() => versionBeingReleased);
             Argument.IsNotNull(() => versionToCheck);
 
-            if (!_versionInfoService.IsStableVersion(versionBeingReleased))
+            // Only non pre-release versions can be merged in to.
+            if (!_versionInfoService.IsReleaseVersion(versionBeingReleased))
             {
                 return false;
             }
 
-            if (versionToCheck.StartsWith(versionBeingReleased))
+            // Only pre-release versions with an "unstable" label prefix are valid to merge.
+            if (!_versionInfoService.IsPreReleaseWithLabelPrefix(versionToCheck, "unstable"))
             {
-                return true;
+                return false;
             }
 
-            return false;
+            // version must be less than the version being released.
+            var versionComparison = _versionInfoService.CompareVersions(versionToCheck, versionBeingReleased);
+            switch (versionComparison)
+            {
+                case VersionComparisonResult.LessThan:
+                    return true;
+                case VersionComparisonResult.Unknown:
+                    Log.Warning("Unable to compare version {0} with version {1}. Version {0} will not be included in the Merge.", versionToCheck, versionBeingReleased);
+                    return false;
+                default:
+                    return false;
+            }
+
         }
     }
 }

--- a/src/JiraCli/Services/VersionInfoService.cs
+++ b/src/JiraCli/Services/VersionInfoService.cs
@@ -9,24 +9,113 @@ namespace JiraCli.Services
 {
     using System;
     using Catel;
+    using Semver;
 
     public class VersionInfoService : IVersionInfoService
     {
-        public bool IsStableVersion(string version)
+        public bool IsReleaseVersion(string version)
         {
             Argument.IsNotNull(() => version);
 
-            // Assume that if we can parse it, it's a stable version
+            // Can assume semver format.
+            SemVersion semVer;
+            if (SemVersion.TryParse(version, out semVer))
+            {
+                if (string.IsNullOrWhiteSpace(semVer.Prerelease))
+                {
+                    // it's not a pre-release.
+                    return true;
+                }
+            }
+            else
+            {
+                // the version isn't compatible with semver.
+                // Assume that if we can parse it, it's a release version
+                Version ver;
+                if (Version.TryParse(version, out ver))
+                {
+                    return true;
+                }
+            }
 
-            try
+            return false;
+
+        }
+
+        public VersionComparisonResult CompareVersions(string versionToCheck, string versionToCompareAgainst)
+        {
+
+            Argument.IsNotNull(() => versionToCheck);
+            Argument.IsNotNull(() => versionToCompareAgainst);
+
+            SemVersion semanticVersionToCheck;
+            bool hasParsedVersionToCheck = SemVersion.TryParse(versionToCheck, out semanticVersionToCheck);
+
+            SemVersion semanticVersionToCompareAgainst;
+            bool hasParsedVersionToCompareAgainst = SemVersion.TryParse(versionToCompareAgainst, out semanticVersionToCompareAgainst);
+
+            // either both have to be semver or both have to be ordinary to compare.
+            if (hasParsedVersionToCheck && hasParsedVersionToCompareAgainst)
             {
-                var parsedVersion = new Version(version);
-                return true;
+                int result = semanticVersionToCheck.CompareByPrecedence(versionToCompareAgainst);
+                return ConvertToComparisonResult(result);
             }
-            catch (Exception)
+
+            // either one or both version numbers are not sem ver compatible. fallback to attempting non semver version comparison.
+
+            Version verToCheck;
+            hasParsedVersionToCheck = Version.TryParse(versionToCheck, out verToCheck);
+
+            Version verToCompareAgainst;
+            hasParsedVersionToCompareAgainst = Version.TryParse(versionToCompareAgainst, out verToCompareAgainst);
+
+            if (hasParsedVersionToCheck && hasParsedVersionToCompareAgainst)
             {
-                return false;
+                int result = verToCheck.CompareTo(verToCompareAgainst);
+                return ConvertToComparisonResult(result);
             }
+
+            // attempting to compare semver with non semver, or unable to parse version numbers.
+            return VersionComparisonResult.Unknown;
+
+        }
+
+        private VersionComparisonResult ConvertToComparisonResult(int result)
+        {
+            if (result < 0)
+            {
+                return VersionComparisonResult.LessThan;
+            }
+
+            if (result > 0)
+            {
+                return VersionComparisonResult.GreaterThan;
+            }
+
+            return VersionComparisonResult.Equal;
+
+        }
+
+        public bool IsPreReleaseWithLabelPrefix(string version, string labelPrefix)
+        {
+            Argument.IsNotNull(() => version);
+            Argument.IsNotNull(() => labelPrefix);
+
+            // Can assume semver format.
+            SemVersion semVer;
+            if (SemVersion.TryParse(version, out semVer))
+            {
+                if (!string.IsNullOrWhiteSpace(semVer.Prerelease))
+                {
+                    if (semVer.Prerelease.ToLowerInvariant().StartsWith(labelPrefix.ToLowerInvariant()))
+                    {
+                        // it's a pre-release and the label contains the specified prefix.
+                        return true;
+                    }
+                }
+            }
+           
+            return false;
         }
     }
 }

--- a/src/JiraCli/Services/VersionInfoService.cs
+++ b/src/JiraCli/Services/VersionInfoService.cs
@@ -17,7 +17,7 @@ namespace JiraCli.Services
         {
             Argument.IsNotNull(() => version);
 
-            // Can assume semver format.
+            // Attempt semver format.
             SemVersion semVer;
             if (SemVersion.TryParse(version, out semVer))
             {
@@ -39,7 +39,6 @@ namespace JiraCli.Services
             }
 
             return false;
-
         }
 
         public VersionComparisonResult CompareVersions(string versionToCheck, string versionToCompareAgainst)

--- a/src/JiraCli/Services/VersionService.cs
+++ b/src/JiraCli/Services/VersionService.cs
@@ -145,7 +145,7 @@ namespace JiraCli.Services
 
             Log.Info("Merging all prerelease versions into '{0}'", version);
 
-            if (!_versionInfoService.IsStableVersion(version))
+            if (!_versionInfoService.IsReleaseVersion(version))
             {
                 Log.Info("Version '{0}' is not a stable version, versions will not be merged", version);
                 return;
@@ -196,5 +196,7 @@ namespace JiraCli.Services
 
             return existingVersion;
         }
+
+       
     }
 }

--- a/src/JiraCli/packages.config
+++ b/src/JiraCli/packages.config
@@ -11,4 +11,5 @@
   <package id="ModuleInit.Fody" version="1.5.8.0" targetFramework="net4" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
   <package id="RestSharp" version="105.1.0" targetFramework="net4" />
+  <package id="semver" version="1.1.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Changed which versions are included when doing a merge. Now, all "unstable" versions (that is, version numbers that have a pre-release label starting with a prefix "unstable") preceeding the given release version are now included.

As part of this change, I have adopted a semver library: https://github.com/maxhauser/semver/ to allow easier parsing / inspection of semver version numbers.

I also ended up renaming the IsStableVersion method to IsReleaseVersion, because IsStable implies >= 1.0.0 according to semver, but we just care about whether it has a pre-release lable or not, to cover the cases where we want to include 0.Y.Z versions in the merge.

Added / Extended test cases to cover new logic.
