### PR TITLE
Fixes bug with date serialisation, and git version change from "unstable" to "alpha"

### DIFF
--- a/src/JiraCli.Tests/JiraCli.Tests.csproj
+++ b/src/JiraCli.Tests/JiraCli.Tests.csproj
@@ -38,30 +38,30 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Catel.Core, Version=4.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Catel.Core.4.2.0-unstable0284\lib\net40\Catel.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Catel.Fody.Attributes, Version=2.8.0.0, Culture=neutral, PublicKeyToken=1c8163524cbe02e6, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Catel.Fody.2.8.0\lib\portable-net4+sl4+wp7+win8+wpa81+MonoAndroid14+MonoTouch40\Catel.Fody.Attributes.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks">
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\lib\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -69,16 +69,16 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.IO">
+    <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Runtime">
+    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks">
+    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -138,15 +138,15 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Import Project="..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
+    <Error Condition="!Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
+  <Import Project="..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/JiraCli.Tests/JiraCli.Tests.csproj
+++ b/src/JiraCli.Tests/JiraCli.Tests.csproj
@@ -38,30 +38,30 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Catel.Core, Version=4.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Catel.Core.4.2.0-unstable0284\lib\net40\Catel.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Catel.Fody.Attributes, Version=2.8.0.0, Culture=neutral, PublicKeyToken=1c8163524cbe02e6, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Catel.Fody.2.8.0\lib\portable-net4+sl4+wp7+win8+wpa81+MonoAndroid14+MonoTouch40\Catel.Fody.Attributes.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Threading.Tasks">
       <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
       <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework">
       <HintPath>..\..\lib\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -69,16 +69,16 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.IO">
       <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Runtime">
       <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Threading.Tasks">
       <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -138,15 +138,15 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
+  <Import Project="..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
     <Error Condition="!Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
   </Target>
-  <Import Project="..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Import Project="..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/JiraCli.Tests/packages.config
+++ b/src/JiraCli.Tests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Catel.Core" version="4.2.0-unstable0284" targetFramework="net4" />
-  <package id="Catel.Fody" version="2.8.0" targetFramework="net4" developmentDependency="true" />
-  <package id="Fody" version="1.29.2" targetFramework="net4" developmentDependency="true" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net4" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net4" />
-  <package id="ModuleInit.Fody" version="1.5.8.0" targetFramework="net4" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
-  <package id="NUnit" version="2.6.4" targetFramework="net4" />
+  <package id="Catel.Core" version="4.2.0-unstable0284" targetFramework="net40" />
+  <package id="Catel.Fody" version="2.8.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Fody" version="1.29.2" targetFramework="net40" developmentDependency="true" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
+  <package id="ModuleInit.Fody" version="1.5.8.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>

--- a/src/JiraCli.sln
+++ b/src/JiraCli.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraCli", "JiraCli\JiraCli.csproj", "{306289C1-A5C5-4C32-BAFE-C1F7E5331291}"
 EndProject

--- a/src/JiraCli/Extensions/JiraExtensions.version.cs
+++ b/src/JiraCli/Extensions/JiraExtensions.version.cs
@@ -16,6 +16,15 @@ namespace JiraCli
     using Newtonsoft.Json.Linq;
     using RestSharp;
     using RestSharp.Serializers;
+    using Newtonsoft.Json.Converters;
+
+    class CustomDateTimeConverter : IsoDateTimeConverter
+    {
+        public CustomDateTimeConverter()
+        {
+            base.DateTimeFormat = "yyyy-MM-dd";
+        }
+    }
 
     public static partial class JiraExtensions
     {
@@ -85,6 +94,11 @@ namespace JiraCli
 
             var resource = string.Format("rest/api/2/project/{0}/versions", projectKey);
             var responseJson = jiraRestClient.ExecuteRequest(Method.GET, resource);
+
+            //var format = "yyyy-MM-dd"; // your datetime format
+            //var dateTimeConverter = new IsoDateTimeConverter { DateTimeFormat = format };
+
+           // var ld = JsonConvert.DeserializeObject<EoiDraftViewModel>(json, dateTimeConverter);
 
             foreach (var jsonElement in responseJson.Children())
             {

--- a/src/JiraCli/Extensions/JiraExtensions.version.cs
+++ b/src/JiraCli/Extensions/JiraExtensions.version.cs
@@ -7,24 +7,12 @@
 
 namespace JiraCli
 {
-    using System;
     using System.Collections.Generic;
     using Atlassian.Jira;
     using Catel;
     using Models;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using RestSharp;
-    using RestSharp.Serializers;
-    using Newtonsoft.Json.Converters;
-
-    class CustomDateTimeConverter : IsoDateTimeConverter
-    {
-        public CustomDateTimeConverter()
-        {
-            base.DateTimeFormat = "yyyy-MM-dd";
-        }
-    }
 
     public static partial class JiraExtensions
     {
@@ -93,12 +81,7 @@ namespace JiraCli
             var projectVersions = new List<JiraProjectVersion>();
 
             var resource = string.Format("rest/api/2/project/{0}/versions", projectKey);
-            var responseJson = jiraRestClient.ExecuteRequest(Method.GET, resource);
-
-            //var format = "yyyy-MM-dd"; // your datetime format
-            //var dateTimeConverter = new IsoDateTimeConverter { DateTimeFormat = format };
-
-           // var ld = JsonConvert.DeserializeObject<EoiDraftViewModel>(json, dateTimeConverter);
+            var responseJson = jiraRestClient.ExecuteRequest(Method.GET, resource);          
 
             foreach (var jsonElement in responseJson.Children())
             {

--- a/src/JiraCli/FodyWeavers.xml
+++ b/src/JiraCli/FodyWeavers.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers>
   <ModuleInit/>
-  <Costura/>
   <Catel/>
+  <Costura/>
 </Weavers>

--- a/src/JiraCli/Formatter/CustomDateTimeConverter.cs
+++ b/src/JiraCli/Formatter/CustomDateTimeConverter.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json.Converters;
+
+namespace JiraCli.Models.Formatter
+{
+    class CustomDateTimeConverter : IsoDateTimeConverter
+    {
+        public CustomDateTimeConverter()
+        {
+            base.DateTimeFormat = "yyyy-MM-dd";
+        }
+    }
+}

--- a/src/JiraCli/JiraCli.csproj
+++ b/src/JiraCli/JiraCli.csproj
@@ -38,57 +38,55 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Atlassian.Jira, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Atlassian.SDK.4.4.0\lib\Atlassian.Jira.dll</HintPath>
+      <HintPath>..\..\..\packages\Atlassian.SDK.4.4.0\lib\Atlassian.Jira.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Catel.Core, Version=4.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Catel.Core.4.2.0-unstable0284\lib\net40\Catel.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Catel.Core.4.2.0-unstable0284\lib\net40\Catel.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Catel.Fody.Attributes, Version=2.8.0.0, Culture=neutral, PublicKeyToken=1c8163524cbe02e6, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Catel.Fody.2.8.0\lib\portable-net4+sl4+wp7+win8+wpa81+MonoAndroid14+MonoTouch40\Catel.Fody.Attributes.dll</HintPath>
+      <HintPath>..\..\..\packages\Catel.Fody.2.8.0\lib\portable-net4+sl4+wp7+win8+wpa81+MonoAndroid14+MonoTouch40\Catel.Fody.Attributes.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks">
-      <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
-      <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Semver">
-      <HintPath>..\..\lib\semver.1.1.2\lib\net40\Semver.dll</HintPath>
+    <Reference Include="Semver, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\semver.1.1.2\lib\net40\Semver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO">
-      <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
+    <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
+    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
+    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -157,8 +155,12 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
   <Import Project="..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
+  <Import Project="..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/JiraCli/JiraCli.csproj
+++ b/src/JiraCli/JiraCli.csproj
@@ -38,55 +38,57 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Atlassian.Jira, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Atlassian.SDK.4.4.0\lib\Atlassian.Jira.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Atlassian.SDK.4.4.0\lib\Atlassian.Jira.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Catel.Core, Version=4.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Catel.Core.4.2.0-unstable0284\lib\net40\Catel.Core.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Catel.Core.4.2.0-unstable0284\lib\net40\Catel.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Catel.Fody.Attributes, Version=2.8.0.0, Culture=neutral, PublicKeyToken=1c8163524cbe02e6, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Catel.Fody.2.8.0\lib\portable-net4+sl4+wp7+win8+wpa81+MonoAndroid14+MonoTouch40\Catel.Fody.Attributes.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Catel.Fody.2.8.0\lib\portable-net4+sl4+wp7+win8+wpa81+MonoAndroid14+MonoTouch40\Catel.Fody.Attributes.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\lib\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Semver, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\semver.1.1.2\lib\net40\Semver.dll</HintPath>
+    <Reference Include="Semver">
+      <HintPath>..\..\lib\semver.1.1.2\lib\net40\Semver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
+    <Reference Include="System.IO">
+      <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\lib\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -155,12 +157,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
   <Import Project="..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\lib\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
-  <Import Project="..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
-  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/JiraCli/JiraCli.csproj
+++ b/src/JiraCli/JiraCli.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Logging\OutputLogListener.cs" />
     <Compile Include="Managers\ActionManager.cs" />
     <Compile Include="Managers\Interfaces\IActionManager.cs" />
+    <Compile Include="Formatter\CustomDateTimeConverter.cs" />
     <Compile Include="Models\JiraIssue.cs" />
     <Compile Include="Models\JiraIssueUpdate.cs" />
     <Compile Include="Models\JiraObjectBase.cs" />

--- a/src/JiraCli/Models/JiraProjectVersion.cs
+++ b/src/JiraCli/Models/JiraProjectVersion.cs
@@ -7,6 +7,7 @@
 
 namespace JiraCli.Models
 {
+    using Newtonsoft.Json;
     using System;
 
     public class JiraProjectVersion : JiraObjectBase
@@ -19,9 +20,10 @@ namespace JiraCli.Models
 
         public bool Released { get; set; }
 
+        [JsonConverter(typeof(CustomDateTimeConverter))]
         public DateTime? ReleaseDate { get; set; }
 
-        public DateTime? UserReleaseDate { get; set; }
+        public string UserReleaseDate { get; set; }
 
         public string Project { get; set; }
 

--- a/src/JiraCli/Services/Interfaces/IVersionInfoService.cs
+++ b/src/JiraCli/Services/Interfaces/IVersionInfoService.cs
@@ -5,10 +5,14 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 
+using System;
+
 namespace JiraCli.Services
 {
     public interface IVersionInfoService
     {
+        bool IsPreRelease(string version, Predicate<string> labelChecker);
+        bool IsPreRelease(string version);
         bool IsPreReleaseWithLabelPrefix(string version, string labelPrefix);
         bool IsReleaseVersion(string version);
         VersionComparisonResult CompareVersions(string versionToCheck, string versionBeingReleased);

--- a/src/JiraCli/Services/Interfaces/IVersionInfoService.cs
+++ b/src/JiraCli/Services/Interfaces/IVersionInfoService.cs
@@ -4,11 +4,10 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
-using System;
-
 namespace JiraCli.Services
 {
+    using System;
+
     public interface IVersionInfoService
     {
         bool IsPreRelease(string version, Predicate<string> labelChecker);

--- a/src/JiraCli/Services/MergeVersionService.cs
+++ b/src/JiraCli/Services/MergeVersionService.cs
@@ -36,7 +36,13 @@ namespace JiraCli.Services
             }
 
             // Only pre-release versions with an "unstable" label prefix are valid to merge.
-            if (!_versionInfoService.IsPreReleaseWithLabelPrefix(versionToCheck, "unstable"))
+            // semVer.Prerelease.ToLowerInvariant().StartsWith(labelPrefix.ToLowerInvariant())
+
+            if (!_versionInfoService.IsPreRelease(versionToCheck, (label) =>
+            {
+                return label.ToLowerInvariant().StartsWith("unstable") ||
+                       label.ToLowerInvariant().StartsWith("alpha");
+            }))
             {
                 return false;
             }

--- a/src/JiraCli/Services/VersionInfoService.cs
+++ b/src/JiraCli/Services/VersionInfoService.cs
@@ -95,6 +95,40 @@ namespace JiraCli.Services
 
         }
 
+        public bool IsPreRelease(string version, Predicate<string> prereleaseLabelChecker)
+        {
+            Argument.IsNotNull(() => version);
+
+            // Can assume semver format.
+            SemVersion semVer;
+            if (SemVersion.TryParse(version, out semVer))
+            {
+                if (!string.IsNullOrWhiteSpace(semVer.Prerelease))
+                {
+                    return prereleaseLabelChecker(semVer.Prerelease);
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsPreRelease(string version)
+        {
+            Argument.IsNotNull(() => version);            
+
+            // Can assume semver format.
+            SemVersion semVer;
+            if (SemVersion.TryParse(version, out semVer))
+            {
+                if (!string.IsNullOrWhiteSpace(semVer.Prerelease))
+                {
+                    
+                }
+            }
+
+            return false;
+        }
+
         public bool IsPreReleaseWithLabelPrefix(string version, string labelPrefix)
         {
             Argument.IsNotNull(() => version);

--- a/src/JiraCli/Services/VersionInfoService.cs
+++ b/src/JiraCli/Services/VersionInfoService.cs
@@ -122,7 +122,7 @@ namespace JiraCli.Services
             {
                 if (!string.IsNullOrWhiteSpace(semVer.Prerelease))
                 {
-                    
+                    return true;
                 }
             }
 

--- a/src/JiraCli/Services/VersionService.cs
+++ b/src/JiraCli/Services/VersionService.cs
@@ -10,13 +10,10 @@ namespace JiraCli.Services
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using Atlassian.Jira;
-    using Atlassian.Jira.Remote;
     using Catel;
     using Catel.Logging;
     using Models;
-    using RestSharp;
 
     public class VersionService : IVersionService
     {
@@ -161,6 +158,8 @@ namespace JiraCli.Services
                 if (_mergeVersionService.ShouldBeMerged(version, remoteVersion.Name))
                 {
                     versionsToMerge.Add(remoteVersion);
+
+                   
                 }
             }
 

--- a/src/JiraCli/packages.config
+++ b/src/JiraCli/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Atlassian.SDK" version="4.4.0" targetFramework="net4" />
-  <package id="Catel.Core" version="4.2.0-unstable0284" targetFramework="net4" />
-  <package id="Catel.Fody" version="2.8.0" targetFramework="net4" developmentDependency="true" />
-  <package id="Costura.Fody" version="1.3.3.0" targetFramework="net4" developmentDependency="true" />
-  <package id="Fody" version="1.29.2" targetFramework="net4" developmentDependency="true" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net4" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net4" />
-  <package id="ModuleInit.Fody" version="1.5.8.0" targetFramework="net4" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
-  <package id="RestSharp" version="105.1.0" targetFramework="net4" />
+  <package id="Atlassian.SDK" version="4.4.0" targetFramework="net40" />
+  <package id="Catel.Core" version="4.2.0-unstable0284" targetFramework="net40" />
+  <package id="Catel.Fody" version="2.8.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Costura.Fody" version="1.3.3.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Fody" version="1.29.2" targetFramework="net40" developmentDependency="true" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
+  <package id="ModuleInit.Fody" version="1.5.8.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net40" />
   <package id="semver" version="1.1.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
When calling the jira rest API to get project versions, the ProjectVersion dto that gets deserialised from the json has acouple of dates that weren;t being handled correctly and were generating serialisation errors. This wasn't noticed previously as we didn't have these fields populated in Jira until actual issuing a versions as "Released" and entering in a release date.

Also we updated our version of GitVersion that we use during builds. The older GitVersion used to use "alpha" in the version numbers pre-release label, but now that has switched to "unstable". The MergeVersions functionality was explicitly looking for versions with "unstable" in the label to merge, but with this PR it now handles them both. In future I think we need to make this configurable.
